### PR TITLE
fixed link path

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -79,4 +79,4 @@ It also helps to untangle your YAML file.
 
 ## Next
 
-See [advanced usage](docs/advanced.md) for more features.
+See [advanced usage](advanced.md) for more features.


### PR DESCRIPTION
Link is relative path. If use absolute path, format is https://github.com/AlexanderWillner/kingraph/blob/master/docs/advanced.md, not docs/advanced.md